### PR TITLE
tools/compulab-setup-env: Fix check for existing environment in case of using docker

### DIFF
--- a/tools/compulab-setup-env
+++ b/tools/compulab-setup-env
@@ -36,7 +36,7 @@ eof
     done
 }
 
-if [[ -d ${BD} ]];then
+if [[ -d ${BD} && -n "$(ls -A ${BD})" ]];then
 
 echo "Back to the build environment ${BD}"
 . setup-environment ${BD}


### PR DESCRIPTION
When using docker image for building, in order to mount build directory between both environments, meaning host and docker, the build directory has to already exist. Due to this the current check is insufficient.

We are checking if it is empty (newly created).